### PR TITLE
fix: Allow commenting out backend.cfg

### DIFF
--- a/.devilbox/www/include/lib/container/Httpd.php
+++ b/.devilbox/www/include/lib/container/Httpd.php
@@ -217,6 +217,10 @@ class Httpd extends BaseClass implements BaseInterface
 		$cont = stream_get_contents($fp);
 		fclose($fp);
 
+		$semicolon_pos = strpos($cont, ';');
+		if($semicolon_pos !== false && $semicolon_pos == 0) {
+				return 'default';
+		}
 		// conf:<type>:<proto>:<server>:<port>
 		$arr = explode(':', $cont);
 


### PR DESCRIPTION
Regarding issue [#950](https://github.com/cytopia/devilbox/issues/950)

Did not see any processing regarding if the option is commented out or not.
Now we check if the first symbol is a semicolon (;) and in case it is, we return `default` rather than the commented out option.