### PR TITLE
docs: Update documentation with 3 env. vars. not mentioned till now.

### DIFF
--- a/compose/docker-compose.override.yml-php-multi.yml
+++ b/compose/docker-compose.override.yml-php-multi.yml
@@ -47,6 +47,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -65,6 +66,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -79,6 +81,7 @@ services:
       # Specific volumes
       - ${DEVILBOX_PATH}/cfg/php-ini-5.6:/etc/php-custom.d:ro${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/cfg/php-fpm-5.6:/etc/php-fpm-custom.d:ro${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/cfg/php-startup-5.6:/startup.1.d:rw${MOUNT_OPTIONS}
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
@@ -101,6 +104,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -119,6 +123,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -137,6 +142,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -155,6 +161,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -173,6 +180,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -191,6 +199,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -209,6 +218,7 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}
 
@@ -227,5 +237,6 @@ services:
       # Generic volumes
       - ${HOST_PATH_HTTPD_DATADIR}:/shared/httpd:rw${MOUNT_OPTIONS}
       - ${DEVILBOX_PATH}/supervisor:/etc/supervisor/custom.d:rw${MOUNT_OPTIONS}
+      - ${HOST_PATH_BACKUPDIR}:/shared/backups:rw${MOUNT_OPTIONS}
       # - ${DEVILBOX_PATH}/autostart:/startup.2.d:rw${MOUNT_OPTIONS}
       - devilbox-mail:/var/mail:rw${MOUNT_OPTIONS}

--- a/docs/configuration-files/env-file.rst
+++ b/docs/configuration-files/env-file.rst
@@ -1593,6 +1593,26 @@ be able to display information inside the bundled intranet.
    Keep this variable in sync with the actual MySQL root password.
 
 
+MySQL Dump Secure
+-----------------
+
+.. _env_mysql_dump_secure:
+
+Those variables are used on ``docker-entrypoint`` in order to create a ``cnf`` file for the ``mysqldump-secure`` command.
+By default they should work correctly for the PHP container specified in ``.env`` but if they are left undeclared in multi-php setup,
+the other PHP containers would not be able to dump the database correctly.
+
++-------------------------+-------------------+---------------------+
+| Name                    | Allowed values    | Default value       |
++=========================+===================+=====================+
+| ``MYSQL_BACKUP_USER``   | any string        | none                |
++-------------------------+-------------------+---------------------+
+| ``MYSQL_BACKUP_PASS``   | any string        | none                |
++-------------------------+-------------------+---------------------+
+| ``MYSQL_BACKUP_HOST``   | any string        | none                |
++-------------------------+-------------------+---------------------+
+
+
 PostgreSQL
 ----------
 

--- a/docs/maintenance/backup-and-restore-mysql.rst
+++ b/docs/maintenance/backup-and-restore-mysql.rst
@@ -33,6 +33,10 @@ dump date, dump options as well as the server version it came from.
 Mysqldump-secure
 ----------------
 
+.. note::
+   On multi-PHP setup make sure you have the :ref:`following variables <env_mysql_dump_secure>` declared.
+   In case they are missing the ``mysqldump-secure`` command will fail on PHP containers other than the default.
+
 |ext_lnk_tool_mysqldump_secure|  is bundled, setup and ready to use in every PHP container.
 You can run it without any arguments and it will dump each available database as a
 separated compressed file. Backups will be located in ``./backups/mysql/`` inside the Devilbox


### PR DESCRIPTION
# Fixes for issue

### Goal
Improve documentation and prevent future misunderstandings due to the user being unaware of certain variables.
Add missing mounts for the multi PHP setup

## Description

### Documentation Commit

The following variables:
* `MYSQL_BACKUP_USER`
* `MYSQL_BACKUP_PASS`
* `MYSQL_BACKUP_HOST`

Are used for generating the `mysqldump-secure` configuration file [as can be seen here](https://github.com/devilbox/docker-php-fpm/blob/042023514ddb26289f7fe7565dc03eadfdc56bff/Dockerfiles/slim/data/docker-entrypoint.sh#L191)
In case they are missing from the `.env` file, the `mysqldump-secure` command cannot be run successfully on containers other than the default one.

### Multi PHP issue

Here the issue was that the `backups` directory was not mounting to the given container, probably because of the missing declaration. Was added and tested, now `mysqldump-secure` should be able to write to the host directory regardless from which container it is started.